### PR TITLE
Add just plain lib/perl5 to perl module paths

### DIFF
--- a/scripts/nix-bootstrap-home.sh
+++ b/scripts/nix-bootstrap-home.sh
@@ -33,7 +33,7 @@ export PATH=$HOME/nix-boot/bin:$PATH
 export PKG_CONFIG_PATH=$HOME/nix-boot/lib/pkgconfig:$PKG_CONFIG_PATH
 export LDFLAGS="-L$HOME/nix-boot/lib $LDFLAGS"
 export CPPFLAGS="-I$HOME/nix-boot/include $CPPFLAGS"
-export PERL5OPT="-I$HOME/nix-boot/lib/perl -I$HOME/nix-boot/lib64/perl5"
+export PERL5OPT="-I$HOME/nix-boot/lib/perl -I$HOME/nix-boot/lib64/perl5 -I$HOME/nix-boot/lib/perl5"
 export nix=$HOME/nix-boot
 
 if [ ! -e $nix/lib/libbz2.so.1.0.6 ]; then

--- a/scripts/nix-bootstrap-home.sh
+++ b/scripts/nix-bootstrap-home.sh
@@ -33,7 +33,7 @@ export PATH=$HOME/nix-boot/bin:$PATH
 export PKG_CONFIG_PATH=$HOME/nix-boot/lib/pkgconfig:$PKG_CONFIG_PATH
 export LDFLAGS="-L$HOME/nix-boot/lib $LDFLAGS"
 export CPPFLAGS="-I$HOME/nix-boot/include $CPPFLAGS"
-export PERL5OPT="-I$HOME/nix-boot/lib/perl -I$HOME/nix-boot/lib64/perl5 -I$HOME/nix-boot/lib/perl5"
+export PERL5OPT="-I$HOME/nix-boot/lib/perl -I$HOME/nix-boot/lib64/perl5 -I$HOME/nix-boot/lib/perl5 -I$HOME/nix-boot/lib/perl5/site_perl"
 export nix=$HOME/nix-boot
 
 if [ ! -e $nix/lib/libbz2.so.1.0.6 ]; then

--- a/scripts/nix-bootstrap-home.sh
+++ b/scripts/nix-bootstrap-home.sh
@@ -110,6 +110,6 @@ echo 'export PATH=$HOME/nix-boot/bin:$PATH'
 echo 'export PKG_CONFIG_PATH=$HOME/nix-boot/lib/pkgconfig:$PKG_CONFIG_PATH'
 echo 'export LDFLAGS="-L$HOME/nix-boot/lib $LDFLAGS"'
 echo 'export CPPFLAGS="-I$HOME/nix-boot/include $CPPFLAGS"'
-echo 'export PERL5OPT="-I$HOME/nix-boot/lib/perl -I$HOME/nix-boot/lib64/perl5"'
+echo 'export PERL5OPT="-I$HOME/nix-boot/lib/perl -I$HOME/nix-boot/lib64/perl5 -I$HOME/nix-boot/lib/perl5 -I$HOME/nix-boot/lib/perl5/site_perl"'
 echo '  and follow https://nixos.org/wiki/How_to_install_nix_in_home_%28on_another_distribution%29'
 


### PR DESCRIPTION
On my system, I got SQLite as `nix-boot/lib/perl5/site_perl/5.12.2/x86_64-linux/DBD/SQLite.pm`. No idea how to update the checks for pm file existence in a portable way, but this at least lets it find the module.
